### PR TITLE
Removed space from log prefix

### DIFF
--- a/clog.go
+++ b/clog.go
@@ -47,8 +47,8 @@ const (
 
 var formats = map[LEVEL]string{
 	TRACE: "[TRACE] ",
-	INFO:  "[ INFO] ",
-	WARN:  "[ WARN] ",
+	INFO:  "[INFO] ",
+	WARN:  "[WARN] ",
 	ERROR: "[ERROR] ",
 	FATAL: "[FATAL] ",
 }


### PR DESCRIPTION
I am not sure if that is intentionally but I noticed when I checked my Gogs Logs and it didn't quite seem right. 
So I searched the source and ended up here. :smile_cat: 